### PR TITLE
Fixes broken ion stream flushing logic; correctly names symbol writin…

### DIFF
--- a/ionc/ion_stream.c
+++ b/ionc/ion_stream.c
@@ -1174,38 +1174,6 @@ iERR _ion_stream_flush_helper(ION_STREAM *stream)
   
   if (_ion_stream_is_dirty(stream)) {
     if (_ion_stream_is_file_backed(stream)) {
-      if (_ion_stream_can_random_seek(stream)) {
-        position = _ion_stream_position(stream);
-		if (_ion_stream_is_fd_backed(stream)) {
-		   if (LSEEK((int)stream->_fp, (long)position, SEEK_SET)) {
-			  FAILWITH(IERR_WRITE_ERROR);
-			}
-		}
-		else {
-			ASSERT(_ion_stream_is_file_backed(stream));
-        if (fseek(stream->_fp, (long)position, SEEK_SET)) {
-
-          FAILWITH(IERR_WRITE_ERROR);
-
-        }
-      }
-      // now we either write through the user handler, or directly to the file
-      if (_ion_stream_is_user_controlled(stream)) {
-        user_stream = &(((ION_STREAM_USER_PAGED *)stream)->_user_stream);
-        while (stream->_dirty_length > 0) {
-            available = (SIZE)(user_stream->limit - user_stream->curr);
-            if (available > stream->_dirty_length) {
-                available = stream->_dirty_length;
-        }
-
-            memcpy(user_stream->curr, stream->_dirty_start, available);
-            user_stream->curr += available;
-            IONCHECK((*(user_stream->handler))(user_stream));
-            stream->_dirty_length -= available;
-            stream->_dirty_start += available;
-        }
-      }
-      }
       // now we either write through the user handler, or directly to the file
       if (_ion_stream_is_user_controlled(stream)) {
         user_stream = &(((ION_STREAM_USER_PAGED *)stream)->_user_stream);

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -1048,7 +1048,7 @@ iERR _ion_writer_write_timestamp_helper(ION_WRITER *pwriter, ION_TIMESTAMP *valu
     iRETURN;
 }
 
-iERR ion_writer_write_symbol_id(hWRITER hwriter, SID value)
+iERR ion_writer_write_symbol_sid(hWRITER hwriter, SID value)
 {
     iENTER;
     ION_WRITER *pwriter;


### PR DESCRIPTION
…g method to match its header.

The removed code appears to have been copied/pasted incorrectly (as evidenced by the duplication and weird indentation/brace placement).

The change in ion_writer makes the implementation of the method match the name in the header. So that it has the potential to be used.