### PR TITLE
Adds API for comparing timestamps for instant equality.

### DIFF
--- a/ionc/inc/ion_timestamp.h
+++ b/ionc/inc/ion_timestamp.h
@@ -75,7 +75,7 @@ struct _ion_timestamp {
 #define ION_TS_SEC       (ION_TS_MIN  | ION_TT_BIT_SEC)
 #define ION_TS_FRAC      (ION_TS_SEC | ION_TT_BIT_FRAC)
 
-#define ION_MAX_TIMESTAMP_STRING (26+DECQUAD_String) /* y-m-dTh:m:s.<dec>+h:m */
+#define ION_MAX_TIMESTAMP_STRING (26+DECQUAD_String) /* y-m-dTh:m:s.<dec>+h:m */ // TODO there is another definition of a similar constant in ion_debug.h that is shorter. Investigate.
 
 /** Get the time precision for the given timestamp object.
  * The precision values are defined as ION_TS_YEAR, ION_TS_MONTH, ION_TS_DAY,
@@ -118,6 +118,12 @@ ION_API_EXPORT iERR ion_timestamp_to_time_t(const ION_TIMESTAMP *ptime, time_t *
  */
 ION_API_EXPORT iERR ion_timestamp_equals(const ION_TIMESTAMP *ptime1, const ION_TIMESTAMP *ptime2,
         BOOL *is_equal, decContext *pcontext);
+
+/** Compare timestamps for instant equality only (i.e. precision and local offsets need not be equivalent).
+ *  NOTE: if this has any use externally, it could be exposed. If not, it should be removed.
+ */
+ION_API_EXPORT iERR ion_timestamp_instant_equals(const ION_TIMESTAMP *ptime1, const ION_TIMESTAMP *ptime2,
+                                  BOOL *is_equal, decContext *pcontext);
 
 /** Initialize ION_TIMESTAMP object with value specified.
  * It will have ION_TS_YEAR precision

--- a/ionc/ion_timestamp_impl.h
+++ b/ionc/ion_timestamp_impl.h
@@ -84,6 +84,9 @@ iERR _ion_timestamp_get_dec_fraction_with_scale(iTIMESTAMP ptime, int32_t scale,
 iERR _ion_timestamp_get_fraction_with_scale(iTIMESTAMP ptime, int32_t scale,
         int32_t *value, decContext *pcontext);
 
+iERR _ion_timestamp_equals_helper(const ION_TIMESTAMP *ptime1, const ION_TIMESTAMP *ptime2,
+                                  BOOL *is_equal, decContext *pcontext, BOOL instant_only);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
ion-tests has two different timestamp equality semantics: equality under the data model (see the spec), and "instant" equality. The latter measures whether two timestamps represent the same instant in time without caring about precision or having the same local offset.

The `_ion_timestamp_to_utc` method has been added because the `ion_timestamp_to_time_t` has platform-specific dependencies and can only handle dates representable in time_t.