### PR TITLE
Adds API for writing full-fidelity ION_INT values; adds support for w…

### DIFF
--- a/ionc/inc/ion_writer.h
+++ b/ionc/inc/ion_writer.h
@@ -148,6 +148,7 @@ ION_API_EXPORT iERR ion_writer_write_int            (hWRITER hwriter, int value)
 ION_API_EXPORT iERR ion_writer_write_int32          (hWRITER hwriter, int32_t value);
 ION_API_EXPORT iERR ion_writer_write_int64          (hWRITER hwriter, int64_t value);
 ION_API_EXPORT iERR ion_writer_write_long           (hWRITER hwriter, long value);
+ION_API_EXPORT iERR ion_writer_write_ion_int        (hWRITER hwriter, ION_INT *value);
 ION_API_EXPORT iERR ion_writer_write_double         (hWRITER hwriter, double value);
 ION_API_EXPORT iERR ion_writer_write_decimal        (hWRITER hwriter, decQuad *value);
 ION_API_EXPORT iERR ion_writer_write_timestamp      (hWRITER hwriter, iTIMESTAMP value);

--- a/ionc/ion_int.c
+++ b/ionc/ion_int.c
@@ -62,7 +62,7 @@ void ion_int_free(ION_INT *iint)
     if (iint && NULL == iint->_owner) {
         if (iint->_digits) {
             ion_xfree(iint->_digits);
-            iint->_digits = NULL;;
+            iint->_digits = NULL;
         }
         ion_xfree(iint);  // TODO: what allocator cover should I be using here?  xalloc?
     }
@@ -1033,7 +1033,6 @@ iERR _ion_int_extend_digits(ION_INT *iint, SIZE digits_needed, BOOL zero_fill)
 
     ASSERT(iint);
 
-    digits_needed += 100;
     if (iint->_len < digits_needed) {
         // realloc
         len = digits_needed * sizeof(II_DIGIT);

--- a/ionc/ion_writer.c
+++ b/ionc/ion_writer.c
@@ -905,6 +905,38 @@ iERR _ion_writer_write_int64_helper(ION_WRITER *pwriter, int64_t value)
     iRETURN;
 }
 
+iERR ion_writer_write_ion_int(hWRITER hwriter, ION_INT *value)
+{
+    iENTER;
+    ION_WRITER *pwriter;
+
+    if (!hwriter)   FAILWITH(IERR_BAD_HANDLE);
+    pwriter = HANDLE_TO_PTR(hwriter, ION_WRITER);
+
+    IONCHECK(_ion_writer_write_ion_int_helper(pwriter, value));
+
+    iRETURN;
+}
+
+iERR _ion_writer_write_ion_int_helper(ION_WRITER *pwriter, ION_INT *value) {
+    iENTER;
+
+    ASSERT(pwriter);
+
+    switch (pwriter->type) {
+        case ion_type_text_writer:
+            IONCHECK(_ion_writer_text_write_ion_int(pwriter, value));
+            break;
+        case ion_type_binary_writer:
+            IONCHECK(_ion_writer_binary_write_ion_int(pwriter, value));
+            break;
+        default:
+            FAILWITH(IERR_INVALID_ARG);
+    }
+
+    iRETURN;
+}
+
 iERR _ion_writer_write_mixed_int_helper(ION_WRITER *pwriter, ION_READER *preader)
 {
     iENTER;
@@ -1192,7 +1224,7 @@ iERR ion_writer_write_blob(hWRITER hwriter, BYTE *p_buf, SIZE length)
     if (!hwriter) FAILWITH(IERR_BAD_HANDLE);
     pwriter = HANDLE_TO_PTR(hwriter, ION_WRITER);
     // p_buf can be null for a null value
-    if (length < 1) FAILWITH(IERR_INVALID_ARG);
+    if (length < 0) FAILWITH(IERR_INVALID_ARG);
 
     IONCHECK(_ion_writer_write_blob_helper(pwriter, p_buf, length));
 

--- a/ionc/ion_writer_impl.h
+++ b/ionc/ion_writer_impl.h
@@ -198,6 +198,7 @@ iERR _ion_writer_write_typed_null_helper(ION_WRITER *pwriter, ION_TYPE type);
 iERR _ion_writer_write_bool_helper(ION_WRITER *pwriter, BOOL value);
 iERR _ion_writer_write_int32_helper(ION_WRITER *pwriter, int32_t value);
 iERR _ion_writer_write_int64_helper(ION_WRITER *pwriter, int64_t value);
+iERR _ion_writer_write_ion_int_helper(ION_WRITER *pwriter, ION_INT *value);
 iERR _ion_writer_write_mixed_int_helper(ION_WRITER *pwriter, ION_READER *preader);
 iERR _ion_writer_write_double_helper(ION_WRITER *pwriter, double value);
 iERR _ion_writer_write_decimal_helper(ION_WRITER *pwriter, decQuad *value);


### PR DESCRIPTION
…riting zero-length lobs.

There was no public API for writing ION_INTs; the maximum size possible to write was 64 bits. Not anymore.