### PR TITLE
Adds support for symbol 0; implements proper unknown max ID semantics…

### DIFF
--- a/ionc/inc/ion_symbol_table.h
+++ b/ionc/inc/ion_symbol_table.h
@@ -37,7 +37,7 @@ typedef enum _ION_SYMBOL_TABLE_TYPE {
     ist_SYSTEM = 3
 } ION_SYMBOL_TABLE_TYPE;
 
-#define UNKNOWN_SID 0 /* symbol id's presume not only is this unknown, but sid's must be positive */
+#define UNKNOWN_SID -1 /* symbol id's presume not only is this unknown, but sid's must be positive */
 
 //
 // Ion Symbol table implementation
@@ -53,6 +53,8 @@ typedef enum _ION_SYMBOL_TABLE_TYPE {
 #define ION_SYS_SYMBOL_IMPORTS             "imports"
 #define ION_SYS_SYMBOL_SYMBOLS             "symbols"
 #define ION_SYS_SYMBOL_MAX_ID              "max_id"
+
+#define ION_SYS_SYMBOL_MAX_ID_UNDEFINED    -1
 
 #define ION_SYS_SID_UNKNOWN                0 /* not necessarily NULL */
 #define ION_SYS_SID_ION                    1 /* "$ion" */

--- a/ionc/ion_catalog_impl.h
+++ b/ionc/ion_catalog_impl.h
@@ -32,7 +32,7 @@ iERR _ion_catalog_open_with_owner_helper(ION_CATALOG **p_pcatalog, hOWNER owner)
 iERR _ion_catalog_get_symbol_table_count_helper(ION_CATALOG *pcatalog, int32_t *p_count);
 iERR _ion_catalog_add_symbol_table_helper(ION_CATALOG *pcatalog, ION_SYMBOL_TABLE *psymtab);
 iERR _ion_catalog_find_symbol_table_helper(ION_CATALOG *pcatalog, ION_STRING *name, int32_t version, ION_SYMBOL_TABLE **p_psymtab);
-iERR _ion_catalog_find_best_match_helper(ION_CATALOG *pcatalog, ION_STRING *name, int32_t version, ION_SYMBOL_TABLE **p_psymtab);
+iERR _ion_catalog_find_best_match_helper(ION_CATALOG *pcatalog, ION_STRING *name, int32_t version, int32_t max_id, ION_SYMBOL_TABLE **p_psymtab);
 iERR _ion_catalog_release_symbol_table_helper(ION_CATALOG *pcatalog, ION_SYMBOL_TABLE *psymtab);
 iERR _ion_catalog_close_helper(ION_CATALOG *pcatalog);
 

--- a/ionc/ion_reader.c
+++ b/ionc/ion_reader.c
@@ -979,6 +979,10 @@ iERR _ion_reader_get_field_sid_helper(ION_READER *preader, SID *p_sid)
         FAILWITH(IERR_INVALID_STATE);
     }
 
+    if (*p_sid <= UNKNOWN_SID) {
+        FAILWITH(IERR_INVALID_SYMBOL);
+    }
+
     iRETURN;
 }
 


### PR DESCRIPTION
… for symbol table imports; disallows ordered structs with zero elements.

The spec now allows the symbol 0 (see the spec for the significance of that).

For shared symbol table imports, when the max ID of the import is null, not an int, or less than zero, it is treated as if it is undefined. When it is undefined and no exact match is found in the catalog, an error must be raised. See https://amznlabs.github.io/ion-docs/symbols.html .

There is a special type ID (0xD1) in Ion binary for "ordered structs" (elements sorted by field name symbol ID). The spec requires these not to be empty. 