### PR TITLE
Adds API to detect negative-zero floats.

### DIFF
--- a/ionc/CMakeLists.txt
+++ b/ionc/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(ionc
   ion_writer.c
   ion_writer_text.c
   ion_decimal.c
+  ion_float.c
 )
 set_property(TARGET ionc PROPERTY C_STANDARD 99)
 target_include_directories(ionc PUBLIC

--- a/ionc/inc/ion_float.h
+++ b/ionc/inc/ion_float.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2009-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -12,25 +12,19 @@
  * language governing permissions and limitations under the License.
  */
 
-//
-// public interfaces and definitions
-//
+#ifndef IONC_ION_FLOAT_H
+#define IONC_ION_FLOAT_H
 
-#ifndef ION_H_
-#define ION_H_
+#include "ion_types.h"
 
-#include "ion_types.h"  // ion_types.h includes ion_errors.h
-#include "ion_string.h"
-#include "ion_timestamp.h"
-#include "ion_decimal.h"
-#include "ion_float.h"
-#include "ion_int.h"
-#include "ion_collection.h"
-#include "ion_symbol_table.h"
-#include "ion_stream.h"
-#include "ion_reader.h"
-#include "ion_writer.h"
-#include "ion_catalog.h"
-#include "ion_debug.h"
-
+#ifdef __cplusplus
+extern "C" {
 #endif
+
+ION_API_EXPORT BOOL ion_float_is_negative_zero(double value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //IONC_ION_FLOAT_H

--- a/ionc/ion_float.c
+++ b/ionc/ion_float.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2009-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+#include "ion.h"
+
+#define ION_FLOAT_NEG_ZERO_DOUBLE 0x8000000000000000
+
+BOOL ion_float_is_negative_zero(double value) {
+    long neg_zero_bits = ION_FLOAT_NEG_ZERO_DOUBLE;
+    return !memcmp(&neg_zero_bits, &value, sizeof(double));
+}
+

--- a/ionc/ion_reader_text.c
+++ b/ionc/ion_reader_text.c
@@ -30,7 +30,7 @@ double _ION_FLOAT64_POS_INF() {
 
 #define ION_FLOAT64_NEG_INF (_ION_FLOAT64_NEG_INF())
 double _ION_FLOAT64_NEG_INF() { 
-  static const uint64_t value = 0x7FF0000000000000;
+  static const uint64_t value = 0xFFF0000000000000;
   return *(double*)&value; 
 }
 


### PR DESCRIPTION
Negative-zero is considered distinct from positive-zero when determining Ion float equivalence under the data model. This provides an API for determining if a float (double) is negative-zero.